### PR TITLE
feat: add seed-based account generation and snapshot recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ log.log
 *.log
 venv/
 accounts.txt
+snapshot.json

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use clap::Parser;
 use futures::stream::{self, StreamExt};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -47,6 +48,16 @@ struct Args {
 
     #[arg(long)]
     accounts_output: Option<String>,
+}
+
+/// Snapshot persisted between runs for deterministic recovery.
+/// Contains the seed for account generation and the faucet nonce
+/// at the start of distribution, so that recovery can correctly
+/// skip already-completed faucet levels.
+#[derive(Serialize, Deserialize, Debug)]
+struct Snapshot {
+    seed: String,
+    faucet_start_nonce: u64,
 }
 
 // mod uniswap;
@@ -310,11 +321,21 @@ async fn start_bench() -> Result<()> {
         Some(guard)
     };
 
-    let contract_config = if args.recover {
+    let (contract_config, seed, snapshot_start_nonce) = if args.recover {
         info!("Starting in recovery mode...");
         let contract_config =
             ContractConfig::load_from_file(&benchmark_config.contract_config_path).unwrap();
-        contract_config
+        let snapshot_json = std::fs::read_to_string("snapshot.json").unwrap_or_else(|e| {
+            panic!("Failed to read snapshot.json in recovery mode: {}", e);
+        });
+        let snapshot: Snapshot = serde_json::from_str(&snapshot_json).unwrap_or_else(|e| {
+            panic!("Failed to parse snapshot.json: {}", e);
+        });
+        let seed_bytes = hex::decode(snapshot.seed.trim()).expect("Invalid hex seed in snapshot.json");
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&seed_bytes);
+        info!("Recovered faucet_start_nonce: {}", snapshot.faucet_start_nonce);
+        (contract_config, seed, Some(snapshot.faucet_start_nonce))
     } else {
         info!("Starting in normal mode...");
         let mut command = format!(
@@ -335,10 +356,15 @@ async fn start_bench() -> Result<()> {
         .unwrap_or_else(|e| {
             panic!("Contract config file not found {}", e);
         });
-        contract_config
+        
+        let seed: [u8; 32] = rand::random();
+        (contract_config, seed, None)
     };
+    tracing::info!("Account generator seed: 0x{}", hex::encode(seed));
+
     let mut accout_generator = AccountGenerator::with_capacity(
         PrivateKeySigner::from_str(&benchmark_config.faucet.private_key).unwrap(),
+        seed,
     );
     let account_ids = accout_generator
         .gen_account(0, benchmark_config.accounts.num_accounts as u64)
@@ -362,7 +388,26 @@ async fn start_bench() -> Result<()> {
     let chain_id = benchmark_config.nodes[0].chain_id;
 
     info!("Initializing Faucet constructor...");
-    let mut start_nonce = contract_config.get_all_token().len() as u64;
+    let faucet_address = PrivateKeySigner::from_str(&benchmark_config.faucet.private_key).unwrap().address();
+    let on_chain_nonce = eth_clients[0].get_pending_txn_count(faucet_address).await.unwrap();
+    // In recover mode, use the saved start_nonce so that the skip logic
+    // correctly identifies already-completed Level 0 transactions.
+    // In normal mode, use the current on-chain nonce.
+    let mut start_nonce = snapshot_start_nonce.unwrap_or(on_chain_nonce);
+    info!("Faucet on-chain nonce: {}, using start_nonce: {}", on_chain_nonce, start_nonce);
+
+    // Save snapshot in normal mode (after we know the start_nonce)
+    if !args.recover {
+        let snapshot = Snapshot {
+            seed: hex::encode(seed),
+            faucet_start_nonce: start_nonce,
+        };
+        let snapshot_json = serde_json::to_string_pretty(&snapshot).unwrap();
+        std::fs::write("snapshot.json", &snapshot_json).unwrap_or_else(|e| {
+            panic!("Failed to write snapshot.json: {}", e);
+        });
+        info!("Snapshot saved to snapshot.json");
+    }
     let eth_faucet_builder = PlanBuilder::create_faucet_tree_plan_builder(
         benchmark_config.faucet.faucet_level as usize,
         benchmark_config.faucet.fauce_eth_balance,

--- a/src/util/gen_account.rs
+++ b/src/util/gen_account.rs
@@ -22,13 +22,15 @@ const CACHE_SIZE: usize = 1024 * 1024;
 pub struct AccountSignerCache {
     signers: Vec<PrivateKeySigner>,
     size: usize,
+    seed: [u8; 32],
 }
 
 impl AccountSignerCache {
-    pub(crate) fn new(size: usize) -> Self {
+    pub(crate) fn new(size: usize, seed: [u8; 32]) -> Self {
         Self {
             signers: Vec::with_capacity(size),
             size,
+            seed,
         }
     }
 
@@ -45,13 +47,16 @@ impl AccountSignerCache {
 
     pub(crate) fn get_signer(&self, index: usize) -> PrivateKeySigner {
         if index >= self.signers.len() {
-            return Self::compute_signer(AccountId(index as u32));
+            return self.compute_signer(AccountId(index as u32));
         }
         self.signers[index].clone()
     }
 
-    fn compute_signer(id: AccountId) -> PrivateKeySigner {
-        let private_key_bytes = keccak256((id.0 as u64).to_le_bytes());
+    fn compute_signer(&self, id: AccountId) -> PrivateKeySigner {
+        let mut data = Vec::with_capacity(40);
+        data.extend_from_slice(&self.seed);
+        data.extend_from_slice(&(id.0 as u64).to_le_bytes());
+        let private_key_bytes = keccak256(&data);
         PrivateKeySigner::from_slice(private_key_bytes.as_slice())
             .context("Failed to create deterministic signer")
             .unwrap()
@@ -65,19 +70,21 @@ pub struct AccountGenerator {
     faucet_accout: PrivateKeySigner,
     faucet_accout_id: AccountId,
     init_nonces: Vec<Arc<AtomicU64>>,
+    seed: [u8; 32],
 }
 
 pub type AccountManager = Arc<AccountGenerator>;
 
 impl AccountGenerator {
-    pub fn with_capacity(faucet_accout: PrivateKeySigner) -> Self {
+    pub fn with_capacity(faucet_accout: PrivateKeySigner, seed: [u8; 32]) -> Self {
         Self {
-            accout_signers: AccountSignerCache::new(CACHE_SIZE),
+            accout_signers: AccountSignerCache::new(CACHE_SIZE, seed),
             accout_addresses: Vec::new(),
             address_to_id: HashMap::new(),
             faucet_accout,
             faucet_accout_id: AccountId(u32::MAX),
             init_nonces: Vec::new(),
+            seed,
         }
     }
 
@@ -156,10 +163,14 @@ impl AccountGenerator {
         start_index: u64,
         end_index: u64,
     ) -> Vec<PrivateKeySigner> {
+        let seed_array = self.seed;
         let accounts = (start_index..end_index)
             .into_par_iter()
-            .map(|seed| {
-                let private_key_bytes = keccak256(seed.to_le_bytes());
+            .map(|index| {
+                let mut data = Vec::with_capacity(40);
+                data.extend_from_slice(&seed_array);
+                data.extend_from_slice(&index.to_le_bytes());
+                let private_key_bytes = keccak256(&data);
 
                 let signer = PrivateKeySigner::from_slice(private_key_bytes.as_slice())
                     .context("Failed to create deterministic signer")
@@ -192,10 +203,14 @@ mod tests {
     fn test_compute_account_address() {
         // Test computing address for specific account IDs
         let test_ids = vec![0, 1, 100, 1000, 10000, 100000, 1000000];
+        let seed = [0u8; 32];
 
         println!("\n=== Account ID to Address Mapping ===");
         for id in test_ids {
-            let private_key_bytes = keccak256((id as u64).to_le_bytes());
+            let mut data = Vec::with_capacity(40);
+            data.extend_from_slice(&seed);
+            data.extend_from_slice(&(id as u64).to_le_bytes());
+            let private_key_bytes = keccak256(&data);
             let signer = PrivateKeySigner::from_slice(private_key_bytes.as_slice()).unwrap();
             let address = signer.address();
 
@@ -214,11 +229,15 @@ mod tests {
         // Search final recipients in batches
         println!("Searching final recipients (0-999999) in batches...");
         let batch_size = 10000;
+        let seed = [0u8; 32];
         for batch_start in (0..1000000).step_by(batch_size) {
             let batch_end = (batch_start + batch_size).min(1000000);
 
             for id in batch_start..batch_end {
-                let private_key_bytes = keccak256((id as u64).to_le_bytes());
+                let mut data = Vec::with_capacity(40);
+                data.extend_from_slice(&seed);
+                data.extend_from_slice(&(id as u64).to_le_bytes());
+                let private_key_bytes = keccak256(&data);
                 let signer = PrivateKeySigner::from_slice(private_key_bytes.as_slice()).unwrap();
                 let address = format!("{:?}", signer.address()).to_lowercase();
 
@@ -237,7 +256,10 @@ mod tests {
                     println!("  Parent index in Level 5: {}", parent_index_in_level5);
                     println!("  Parent account ID: {}", parent_id);
 
-                    let parent_pk = keccak256((parent_id as u64).to_le_bytes());
+                    let mut p_data = Vec::with_capacity(40);
+                    p_data.extend_from_slice(&seed);
+                    p_data.extend_from_slice(&(parent_id as u64).to_le_bytes());
+                    let parent_pk = keccak256(&p_data);
                     let parent_signer = PrivateKeySigner::from_slice(parent_pk.as_slice()).unwrap();
                     println!("  Parent address: {:?}", parent_signer.address());
 
@@ -265,10 +287,14 @@ mod tests {
         println!("Faucet: {:?}", faucet_signer.address());
 
         // Level 0 (first 10 intermediate accounts)
+        let seed = [0u8; 32];
         println!("\nLevel 0 (indices 1000000-1000009):");
         for i in 0..3 {
             let id = 1000000 + i;
-            let pk = keccak256((id as u64).to_le_bytes());
+            let mut data = Vec::with_capacity(40);
+            data.extend_from_slice(&seed);
+            data.extend_from_slice(&(id as u64).to_le_bytes());
+            let pk = keccak256(&data);
             let signer = PrivateKeySigner::from_slice(pk.as_slice()).unwrap();
             println!("  ID {}: {:?}", id, signer.address());
         }
@@ -278,7 +304,10 @@ mod tests {
         println!("\nLevel 1 (indices 1000010-1000109, showing first 3):");
         for i in 0..3 {
             let id = 1000010 + i;
-            let pk = keccak256((id as u64).to_le_bytes());
+            let mut data = Vec::with_capacity(40);
+            data.extend_from_slice(&seed);
+            data.extend_from_slice(&(id as u64).to_le_bytes());
+            let pk = keccak256(&data);
             let signer = PrivateKeySigner::from_slice(pk.as_slice()).unwrap();
             println!("  ID {}: {:?}", id, signer.address());
         }
@@ -300,7 +329,7 @@ mod tests {
         let faucet_signer = PrivateKeySigner::from_slice(&faucet_bytes)
             .expect("failed to create faucet signer");
 
-        let mut generator = AccountGenerator::with_capacity(faucet_signer.clone());
+        let mut generator = AccountGenerator::with_capacity(faucet_signer.clone(), [0u8; 32]);
         let account_ids = generator
             .gen_account(0, num_accounts)
             .expect("failed to generate accounts");
@@ -366,7 +395,7 @@ mod tests {
         let faucet_address = faucet_signer.address();
 
         // Generate accounts
-        let mut generator = AccountGenerator::with_capacity(faucet_signer.clone());
+        let mut generator = AccountGenerator::with_capacity(faucet_signer.clone(), [0u8; 32]);
         let account_ids = generator
             .gen_account(0, num_accounts)
             .expect("failed to generate accounts");


### PR DESCRIPTION
- Replace deterministic index-based private key generation with seed+index hashing via keccak256 to prevent account discovery
- Fix faucet start_nonce bug: use on-chain nonce instead of hardcoded token count, which caused Level 0 to be silently skipped
- Replace seed.txt with snapshot.json containing both seed and faucet_start_nonce for correct recovery behavior
- In recover mode, use saved start_nonce so the nonce skip logic correctly identifies already-completed faucet levels
- Update unit tests to use fixed seed for determinism