### PR TITLE
feat(fee): align bench fees with Gravity 50 Gwei min base fee

### DIFF
--- a/src/eth/txn_builder.rs
+++ b/src/eth/txn_builder.rs
@@ -8,6 +8,15 @@ use alloy::{
 use anyhow::Result;
 use tracing::debug;
 
+/// Max fee per gas for bench transactions (100 Gwei).
+///
+/// Must stay above Gravity's 50 Gwei protocol minimum base fee with headroom
+/// for transient base-fee spikes under load.
+pub const BENCH_MAX_FEE_PER_GAS: u128 = 100_000_000_000;
+
+/// Priority fee (tip) for bench transactions (1 Gwei).
+pub const BENCH_MAX_PRIORITY_FEE_PER_GAS: u128 = 1_000_000_000;
+
 /// TxnBuilder - Build and sign transactions
 pub struct TxnBuilder;
 
@@ -60,8 +69,8 @@ impl TxnBuilder {
             .with_value(eth_amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(10_000_000_000) // 1 gwei
-            .with_max_fee_per_gas(10_000_000_000) // 10 gwei
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(300_000);
 
         Ok(tx_request)
@@ -81,8 +90,8 @@ impl TxnBuilder {
             .with_value(amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(100_000_000)
-            .with_max_fee_per_gas(100_000_000)
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(100_000);
 
         Ok(tx_request)
@@ -100,8 +109,8 @@ impl TxnBuilder {
             .with_value(amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(100_000_000)
-            .with_max_fee_per_gas(100_000_000)
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(100_000);
 
         Ok(tx_request)

--- a/src/txn_plan/constructor/approve.rs
+++ b/src/txn_plan/constructor/approve.rs
@@ -7,6 +7,7 @@ use alloy::{
 
 use crate::{
     config::IERC20,
+    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
     txn_plan::traits::FromTxnConstructor,
     util::gen_account::{AccountId, AccountManager},
 };
@@ -52,8 +53,8 @@ impl FromTxnConstructor for ApproveTokenConstructor {
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(10_000_000_000) // 0.1 gwei
-            .with_max_fee_per_gas(10_000_000_000) // 0.1 gwei
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(100_000); // Standard gas for approve
 
         Ok(tx_request)

--- a/src/txn_plan/constructor/erc20_transfer.rs
+++ b/src/txn_plan/constructor/erc20_transfer.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::IERC20,
+    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
     txn_plan::{addr_pool::AddressPool, FromTxnConstructor},
     util::gen_account::{AccountId, AccountManager},
 };
@@ -64,8 +65,8 @@ impl FromTxnConstructor for Erc20TransferConstructor {
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(10_000_000_000) // 0.1 gwei
-            .with_max_fee_per_gas(10_000_000_000) // 0.1 gwei
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(100_000); // Standard gas for ERC20 transfer
 
         Ok(tx_request)

--- a/src/txn_plan/constructor/faucet.rs
+++ b/src/txn_plan/constructor/faucet.rs
@@ -15,8 +15,14 @@ use std::{
 };
 use tracing::info;
 
-// Gas parameters must match the values used in the plan executor.
-const GAS_PRICE: u64 = 2100000000000000; // 210 Gwei
+// Per-transaction gas cost budget (in wei) used by the faucet plan to reserve
+// enough ETH on each intermediate account to cover its outgoing transactions.
+//
+// Value = max_fee_per_gas * worst-case gas_limit. With BENCH_MAX_FEE_PER_GAS
+// at 100 Gwei and worst-case per-txn gas around 100k (contract calls), the
+// budget is 1e16 wei = 0.01 ETH per txn, leaving headroom for tip and
+// rounding. Bumping max_fee_per_gas requires bumping this in lockstep.
+const GAS_COST_PER_TXN_BUDGET: u64 = 10_000_000_000_000_000;
 
 static NONCE_MAP: std::sync::OnceLock<Arc<Mutex<HashMap<Address, Arc<AtomicU64>>>>> =
     std::sync::OnceLock::new();
@@ -58,7 +64,7 @@ impl<T: FaucetTxnBuilder + 'static> FaucetTreePlanBuilder<T> {
         let round_total_accounts_num = degree.pow(total_levels as u32);
 
         let degree_u256 = U256::from(degree);
-        let gas_cost_per_txn = U256::from(GAS_PRICE);
+        let gas_cost_per_txn = U256::from(GAS_COST_PER_TXN_BUDGET);
 
         let (amount_per_recipient, intermediate_funding_amounts) = if total_levels > 1 {
             // This is a multi-level distribution.
@@ -196,7 +202,7 @@ impl<T: FaucetTxnBuilder + 'static> FaucetTreePlanBuilder<T> {
     ) -> Box<dyn TxnPlan> {
         let senders = self.get_senders_for_level(level);
         let is_final_level = level == self.total_levels.saturating_sub(1);
-        
+
         // Generate descriptive plan name
         let token_name = self.txn_builder.token_name();
         let plan_name = format!("Level{}Faucet{}Plan", level, token_name);

--- a/src/txn_plan/constructor/swap_token_2_token.rs
+++ b/src/txn_plan/constructor/swap_token_2_token.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{IUniswapV2Router, LiquidityPair},
+    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
     txn_plan::{addr_pool::AddressPool, FromTxnConstructor},
     util::gen_account::{AccountId, AccountManager},
 };
@@ -72,8 +73,8 @@ impl FromTxnConstructor for SwapTokenToTokenConstructor {
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(100_000_000) // 0.1 gwei
-            .with_max_fee_per_gas(100_000_000) // 0.1 gwei
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(100_000); // Standard gas for ETH transfer
         Ok(tx_request)
     }

--- a/src/txn_plan/faucet_txn_builder.rs
+++ b/src/txn_plan/faucet_txn_builder.rs
@@ -6,6 +6,8 @@ use alloy::{
     sol_types::SolCall,
 };
 
+use crate::eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS};
+
 // Define the ERC20 interface for transfer
 sol! {
     interface IERC20 {
@@ -45,8 +47,8 @@ impl FaucetTxnBuilder for EthFaucetTxnBuilder {
             .with_value(value)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(10_000_000_000)
-            .with_max_fee_per_gas(10_000_000_000)
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(21_000) // Standard gas for ETH transfer
     }
 
@@ -83,8 +85,8 @@ impl FaucetTxnBuilder for Erc20FaucetTxnBuilder {
             .with_input(calldata.abi_encode())
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(10_000_000_000)
-            .with_max_fee_per_gas(10_000_000_000)
+            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
+            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
             .with_gas_limit(60_000) // A reasonable default for ERC20 transfers
     }
 


### PR DESCRIPTION
## Summary

Gravity-reth now enforces a 50 Gwei protocol minimum base fee
([gravity-reth#335](https://github.com/Galxe/gravity-reth/pull/335)).
Every hardcoded `max_fee_per_gas` / `max_priority_fee_per_gas` in the bench
was below that floor (0.1-10 Gwei), so every bench transaction would be
rejected at txpool admission with `FeeCapBelowMinimumProtocolFeeCap`.

This PR lifts all bench fee values above the floor and re-sizes the
faucet-tree funding budget to match.

## Changes

- **`src/eth/txn_builder.rs`** — add two public constants:
  - `BENCH_MAX_FEE_PER_GAS = 100 Gwei` (2x the 50 Gwei floor, leaves headroom for transient base-fee spikes).
  - `BENCH_MAX_PRIORITY_FEE_PER_GAS = 1 Gwei`.
- **8 call sites replaced** in `txn_builder.rs`, `faucet_txn_builder.rs`, `erc20_transfer.rs`, `approve.rs`, and `swap_token_2_token.rs` — all now reference the constants. Also removed misleading comments (e.g. `// 0.1 gwei` on what was actually 10 Gwei).
- **`src/txn_plan/constructor/faucet.rs`** — the `GAS_PRICE` constant was actually a per-txn gas-cost budget (`gas_price * gas_limit`, used to reserve ETH on intermediate funding accounts). Renamed to `GAS_COST_PER_TXN_BUDGET`, bumped from 2.1e15 wei (0.0021 ETH) to 1e16 wei (0.01 ETH) so multi-level faucet funding still covers contract-call-sized gas at the new 100 Gwei max fee, and clarified the comment.

## Test plan

- [x] `cargo check` passes.
- [ ] Run bench end-to-end against a Gravity cluster and confirm no transactions are rejected with `FeeCapBelowMinimumProtocolFeeCap`.
- [ ] Run the faucet-tree plan with multiple levels and confirm intermediate accounts have sufficient balance to forward transactions.