### PR TITLE
fix(ci): make the Rust pipeline deterministic and green

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v4

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.95.0"
 components = ["cargo", "clippy", "rustc", "rust-std", "rustfmt"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = true
+use_small_heuristics = "Max"
+use_field_init_shorthand = true

--- a/src/util/gen_account.rs
+++ b/src/util/gen_account.rs
@@ -213,6 +213,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "brute-force scan of 1M key derivations; manual lookup utility, too slow for CI; run with `cargo test -- --ignored`"]
     fn test_find_account_by_address() {
         // Find account ID for a specific address
         let target_address = "0x3ece3a612e4e8849a3eaf093c61683b1370f3418";
@@ -308,6 +309,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires a running node at localhost:8545; run with `cargo test -- --ignored`"]
     async fn test_check_account_balances() {
         use crate::eth::EthHttpCli;
 
@@ -367,6 +369,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires a running node at localhost:8545; run with `cargo test -- --ignored`"]
     async fn test_faucet_eth_to_accounts() {
         use crate::eth::{EthHttpCli, TxnBuilder};
         use alloy::primitives::U256;


### PR DESCRIPTION
## Problem

Rust CI is red on `main` and on PRs (e.g. #50). The `Check` job fails at the
**fmt** step, which blocks `Build` (`needs: check`).

The failure was confusing because **`cargo fmt --all -- --check` passes locally
but fails in CI**. Root cause: **`gravity_bench` ships no `rustfmt.toml` of its
own.**

- In CI it is checked out **standalone**, so `rustfmt` falls back to its
  **defaults** → **91 files** are reported non-compliant → fmt fails.
- Locally it lives **nested** under the `gravity-sdk` monorepo, so `rustfmt`
  walks up and silently uses the **parent `gravity-sdk/rustfmt.toml`**
  (`use_small_heuristics = "Max"`, …) → the same tree looks clean.

Two more problems were latent behind the fmt failure (they only surface once
fmt is unblocked, so CI never reached them):

- The toolchain **floats**: the workflow uses `dtolnay/rust-toolchain@stable`
  while the repo pins `1.91.0` via `rust-toolchain.toml` — non-deterministic
  (a new stable release silently changes formatter/lints).
- Three tests would **hang `cargo test --all-features`** in CI: two
  `#[tokio::test]`s require a live node at `localhost:8545`, and
  `test_find_account_by_address` brute-forces **1,000,000** key derivations
  (observed running >60 s) for a target address not in range.

## Fix

| Change | Why |
|---|---|
| **add `rustfmt.toml`** (`use_small_heuristics = "Max"`, `reorder_imports`, `use_field_init_shorthand`) | Make formatting **self-contained** — identical standalone (CI) or nested (local). The tree is **already compliant**, so this is config-only, **no reformatting**. |
| **pin toolchain to `1.95.0`** in `rust-toolchain.toml` **and** the workflow (`dtolnay/rust-toolchain@1.95.0`, both jobs) | Latest stable, **deterministic** — no more floating `@stable`. |
| **`#[ignore]`** the 2 node-dependent tests + the 1M-key brute-force lookup | They need infra / are manual utilities; run on demand with `cargo test -- --ignored`. |

## Verification (locally, toolchain `1.95.0`)

```
cargo fmt --all -- --check     # clean (0 diffs, 0 warnings)
cargo build --release --all-features   # Finished
cargo test --all-features      # test result: ok. 2 passed; 0 failed; 3 ignored
```

`cargo check --all-targets --all-features` also passes — so all four CI steps
(fmt → check → test → build) are green.

> Note: `dtolnay/rust-toolchain@1.95.0` is a valid ref (the action publishes a
> `1.95.0` branch). The node-dependent / brute-force tests still run on demand
> via `cargo test -- --ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
