### PR TITLE
feat(fee): configurable EIP-1559 tip and maxFee via [fee]

### DIFF
--- a/bench_config.template
+++ b/bench_config.template
@@ -16,6 +16,7 @@ workload = "erc20"
 enable_swap_token = false
 # Address pool type: "random" (default) or "weighted" (hot/normal/long-tail distribution)
 address_pool_type = "random"
+
 # Faucet and deployer account configuration
 [faucet]
 # Private key (example, please replace with real private key, the follows is a example of reth)
@@ -49,3 +50,12 @@ duration_secs = 60
 # Sampling strategy: integer (transaction count) or "full" (check all pending)
 # Default is 10
 sampling = 20
+
+# EIP-1559 fee caps (Gwei). Applied to all workloads + faucet cascade.
+# Put [fee] AFTER top-level keys (e.g. nodes=); never before bare keys like nodes.
+# Defaults: tip 500 / maxFee 1000. Faucet gas budget auto-locksteps to
+# max_fee × 350_000 (EIP-7702 gasLimit). Keep max_fee ≥ tip; for Gravity
+# min baseFee ~50 Gwei use max_fee ≥ tip + 50 so the tip fully applies.
+[fee]
+max_fee_per_gas_gwei = 1000
+max_priority_fee_per_gas_gwei = 500

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -18,7 +18,18 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 # ~baseFee + 1 Gwei which is below the threshold and leaves deploy txs
 # stuck in `queued`. Kept under the 1 ETH RPC txfeecap for typical
 # contract gas limits.
-DEPLOY_GAS_PRICE_WEI = 800_000_000_000  # 800 Gwei
+DEPLOY_GAS_PRICE_WEI = 100_000_000_000  # 100 gwei; clamp_gas_price() enforces <1 ETH fee
+
+def clamp_gas_price(gas_limit, gas_price=None):
+    """Keep gas*price under public RPC txfeecap (1 ETH)."""
+    if gas_price is None:
+        gas_price = DEPLOY_GAS_PRICE_WEI
+    max_fee_wei = 10**18 - 10**15
+    if gas_limit and gas_price * gas_limit > max_fee_wei:
+        gas_price = max_fee_wei // gas_limit
+        print(f"  (clamped gasPrice to {gas_price} wei for gas_limit={gas_limit})")
+    return gas_price
+
 
 def filter_abi(full_abi, function_names):
     """Filters an ABI, keeping only specified functions and essential parts like the constructor."""
@@ -141,6 +152,8 @@ def deploy_contract(w3, account, private_key, contract_interface, contract_name,
     except Exception:
         gas_limit = 5_000_000  # Fallback Gas
 
+    gas_price = clamp_gas_price(gas_limit, gas_price)
+
     tx = Contract.constructor(*args).build_transaction({
         'from': account.address, 'nonce': nonce,
         'gas': gas_limit, 'gasPrice': gas_price
@@ -166,7 +179,7 @@ def approve_token(w3, account, private_key, token_contract, spender_address, tok
         'from': account.address,
         'nonce': w3.eth.get_transaction_count(account.address),
         'gas': 100000,
-        'gasPrice': DEPLOY_GAS_PRICE_WEI
+        'gasPrice': clamp_gas_price(100000)
     })
     
     return send_transaction(w3, tx, private_key, f"Approve {token_symbol}") is not None
@@ -186,7 +199,7 @@ def add_liquidity(w3, account, private_key, router_contract, token_a_info, token
         0, 0, account.address, deadline
     ).build_transaction({
         'from': account.address, 'nonce': w3.eth.get_transaction_count(account.address),
-        'gas': 3_000_000, 'gasPrice': DEPLOY_GAS_PRICE_WEI
+        'gas': 3_000_000, 'gasPrice': clamp_gas_price(3_000_000)
     })
     
     receipt = send_transaction(w3, tx, private_key, f"Add Liquidity for {pair_name}")
@@ -207,7 +220,7 @@ def add_liquidity_eth(w3, account, private_key, router_contract, token_info):
     ).build_transaction({
         'from': account.address, 'value': eth_amount,
         'nonce': w3.eth.get_transaction_count(account.address),
-        'gas': 3_000_000, 'gasPrice': DEPLOY_GAS_PRICE_WEI
+        'gas': 3_000_000, 'gasPrice': clamp_gas_price(3_000_000)
     })
     
     receipt = send_transaction(w3, tx, private_key, f"Add Liquidity for {pair_name}")
@@ -307,12 +320,16 @@ def main(args):
     print("\n--- Generating Output File ---")
     final_token_list = []
     for token in deployed_tokens:
+        # Use on-chain balance (liquidity consumes tokens; planning from
+        # initial_supply over-distributes and the last transfer reverts).
+        on_chain_bal = token["contract"].functions.balanceOf(account.address).call()
         final_token_list.append({
             "symbol": token["symbol"],
             "address": token["address"],
             "faucet_address": account.address,
-            "faucet_balance": str(initial_supply),
+            "faucet_balance": str(on_chain_bal),
         })
+        print(f"  faucet_balance {token['symbol']}: {on_chain_bal} (on-chain after deploy/LP)")
 
     final_results = {
         "addresses": {

--- a/src/config/bench_config.rs
+++ b/src/config/bench_config.rs
@@ -47,6 +47,51 @@ pub struct BenchConfig {
     pub address_pool_type: AddressPoolType,
     #[serde(default = "default_log_path")]
     pub log_path: String,
+    /// EIP-1559 fee caps (tip / maxFee). Defaults: tip 500 Gwei, maxFee 1000 Gwei.
+    #[serde(default)]
+    pub fee: FeeConfig,
+}
+
+/// EIP-1559 fee parameters (Gwei units in toml for readability).
+///
+/// Applied process-wide via `eth::init_gas_fees` after config load.
+/// Faucet cascade gas budget auto-locksteps to
+/// `max_fee_per_gas × EIP7702_SET_CODE_GAS_LIMIT` (worst-case mempool reserve).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FeeConfig {
+    /// `maxFeePerGas` in Gwei (default 1000).
+    #[serde(default = "default_max_fee_gwei")]
+    pub max_fee_per_gas_gwei: u64,
+    /// `maxPriorityFeePerGas` (tip) in Gwei (default 500).
+    #[serde(default = "default_priority_fee_gwei")]
+    pub max_priority_fee_per_gas_gwei: u64,
+}
+
+impl Default for FeeConfig {
+    fn default() -> Self {
+        Self {
+            max_fee_per_gas_gwei: default_max_fee_gwei(),
+            max_priority_fee_per_gas_gwei: default_priority_fee_gwei(),
+        }
+    }
+}
+
+fn default_max_fee_gwei() -> u64 {
+    1000
+}
+
+fn default_priority_fee_gwei() -> u64 {
+    500
+}
+
+impl FeeConfig {
+    /// Convert to runtime wei-based fee caps.
+    pub fn to_gas_fees(&self) -> crate::eth::GasFees {
+        crate::eth::GasFees::from_gwei(
+            self.max_fee_per_gas_gwei,
+            self.max_priority_fee_per_gas_gwei,
+        )
+    }
 }
 
 fn default_log_path() -> String {
@@ -151,6 +196,12 @@ impl BenchConfig {
 
         let config: BenchConfig =
             toml::from_str(&content).with_context(|| "Failed to parse config file as TOML")?;
+
+        config
+            .fee
+            .to_gas_fees()
+            .validate()
+            .map_err(|e| anyhow::anyhow!("invalid [fee] config: {}", e))?;
 
         Ok(config)
     }

--- a/src/eth/txn_builder.rs
+++ b/src/eth/txn_builder.rs
@@ -6,27 +6,89 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use anyhow::Result;
+use std::sync::OnceLock;
 use tracing::debug;
 
-/// Max fee per gas for bench transactions (1000 Gwei).
+/// Default max fee per gas (1000 Gwei) when `[fee]` is omitted from toml.
 ///
-/// Must stay above Gravity's ~50 Gwei min base fee with headroom so that
-/// `max_priority_fee_per_gas` (500 Gwei) still fully applies:
-/// `effective_tip = min(tip, maxFee - baseFee)`. Tip must stay in the
-/// hundreds of Gwei range — empirically 1 Gwei never promotes out of
-/// gravity-reth's `queued` bucket.
-///
-/// Also kept low enough that worst-case EIP-7702 stress
-/// (`EIP7702_SET_CODE_GAS_LIMIT` × this) stays under the public RPC
-/// default `rpc.txfeecap` of 1 ETH: 350_000 × 1000 Gwei = 0.35 ETH.
-/// (Previously 5000 Gwei made 7702 reserve 1.75 ETH and testnet rejected it.)
+/// Historical notes: must stay above Gravity's ~50 Gwei min base fee with
+/// headroom so tip fully applies (`effective_tip = min(tip, maxFee - baseFee)`).
+/// Also keep `gasLimit × maxFee` under public RPC `rpc.txfeecap` (1 ETH):
+/// 350_000 × 1000 Gwei = 0.35 ETH for EIP-7702.
 pub const BENCH_MAX_FEE_PER_GAS: u128 = 1_000_000_000_000;
 
-/// Priority fee (tip) for bench transactions (500 Gwei).
+/// Default priority fee / tip (500 Gwei) when `[fee]` is omitted from toml.
 ///
-/// See `BENCH_MAX_FEE_PER_GAS` — 1 Gwei was below the gravity-reth
-/// txpool promotion threshold under load, so transactions never landed.
+/// Empirically raised in #48 for high-TPS promote under load; idle testnet
+/// often works with far lower tips — override via config after probing.
 pub const BENCH_MAX_PRIORITY_FEE_PER_GAS: u128 = 500_000_000_000;
+
+const GWEI: u128 = 1_000_000_000;
+
+/// Runtime EIP-1559 fee caps for all bench-built transactions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GasFees {
+    pub max_fee_per_gas: u128,
+    pub max_priority_fee_per_gas: u128,
+}
+
+impl Default for GasFees {
+    fn default() -> Self {
+        Self {
+            max_fee_per_gas: BENCH_MAX_FEE_PER_GAS,
+            max_priority_fee_per_gas: BENCH_MAX_PRIORITY_FEE_PER_GAS,
+        }
+    }
+}
+
+impl GasFees {
+    /// Build from Gwei units (toml-friendly).
+    pub fn from_gwei(max_fee_gwei: u64, tip_gwei: u64) -> Self {
+        Self {
+            max_fee_per_gas: (max_fee_gwei as u128) * GWEI,
+            max_priority_fee_per_gas: (tip_gwei as u128) * GWEI,
+        }
+    }
+
+    pub fn max_fee_gwei(&self) -> u64 {
+        (self.max_fee_per_gas / GWEI) as u64
+    }
+
+    pub fn tip_gwei(&self) -> u64 {
+        (self.max_priority_fee_per_gas / GWEI) as u64
+    }
+
+    /// Mempool reserve / faucet gas budget slice: `gas_limit × maxFee` (wei).
+    pub fn reserve_wei(&self, gas_limit: u64) -> u128 {
+        self.max_fee_per_gas.checked_mul(gas_limit as u128).expect("gas_limit × max_fee overflow")
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_fee_per_gas == 0 {
+            return Err("max_fee_per_gas must be > 0".into());
+        }
+        if self.max_priority_fee_per_gas > self.max_fee_per_gas {
+            return Err(format!(
+                "max_priority_fee_per_gas ({}) must be <= max_fee_per_gas ({})",
+                self.max_priority_fee_per_gas, self.max_fee_per_gas
+            ));
+        }
+        Ok(())
+    }
+}
+
+static RUNTIME_GAS_FEES: OnceLock<GasFees> = OnceLock::new();
+
+/// Install process-wide fee caps from config (call once after loading toml).
+/// Subsequent calls are ignored; returns whether this call won the install.
+pub fn init_gas_fees(fees: GasFees) -> bool {
+    RUNTIME_GAS_FEES.set(fees).is_ok()
+}
+
+/// Current fee caps: configured runtime value, or compile-time defaults.
+pub fn gas_fees() -> GasFees {
+    RUNTIME_GAS_FEES.get().copied().unwrap_or_default()
+}
 
 /// TxnBuilder - Build and sign transactions
 pub struct TxnBuilder;
@@ -61,6 +123,7 @@ impl TxnBuilder {
         use crate::config::IUniswapV2Router;
         use alloy::sol_types::SolCall;
 
+        let fees = gas_fees();
         let swap_call = IUniswapV2Router::swapExactETHForTokensCall {
             amountOutMin: amount_out_min,
             path,
@@ -77,8 +140,8 @@ impl TxnBuilder {
             .with_value(eth_amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(300_000);
 
         Ok(tx_request)
@@ -92,14 +155,15 @@ impl TxnBuilder {
         nonce: u64,
         chain_id: u64,
     ) -> Result<TransactionRequest> {
+        let fees = gas_fees();
         let tx_request = TransactionRequest::default()
             .with_from(from)
             .with_to(to)
             .with_value(amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(100_000);
 
         Ok(tx_request)
@@ -112,13 +176,14 @@ impl TxnBuilder {
         nonce: u64,
         chain_id: u64,
     ) -> Result<TransactionRequest> {
+        let fees = gas_fees();
         let tx_request = TransactionRequest::default()
             .with_to(to)
             .with_value(amount)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(100_000);
 
         Ok(tx_request)

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,12 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 use crate::{
     actors::{consumer::Consumer, producer::Producer, Monitor, RegisterTxnPlan},
     config::{BenchConfig, ContractConfig, WorkloadType},
-    eth::{EthHttpCli, TxnBuilder, BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
+    eth::{gas_fees, init_gas_fees, EthHttpCli, TxnBuilder},
     txn_plan::{
         addr_pool::AddressPool,
         constructor::{
             delegate_contract_bytecode, FaucetTreePlanBuilder, EIP7702_DELEGATE_DEPLOY_GAS_LIMIT,
+            EIP7702_SET_CODE_GAS_LIMIT,
         },
         faucet_txn_builder::{Erc20FaucetTxnBuilder, EthFaucetTxnBuilder, FaucetTxnBuilder},
         PlanBuilder, TxnPlan,
@@ -282,14 +283,15 @@ async fn deploy_eip7702_delegate(
     let faucet_addr = signer.address();
     let bytecode = Bytes::from(delegate_contract_bytecode());
 
+    let fees = gas_fees();
     let tx_request = alloy::rpc::types::TransactionRequest::default()
         .with_from(faucet_addr)
         .with_deploy_code(bytecode)
         .with_nonce(faucet_nonce)
         .with_chain_id(chain_id)
-        // 500k × 1000 Gwei = 0.5 ETH < public RPC 1 ETH txfeecap
-        .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-        .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+        // Keep gasLimit × maxFee under public RPC txfeecap (default 1 ETH).
+        .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+        .with_max_fee_per_gas(fees.max_fee_per_gas)
         .with_gas_limit(EIP7702_DELEGATE_DEPLOY_GAS_LIMIT);
 
     let envelope = TxnBuilder::build_and_sign_transaction(tx_request, &signer)?;
@@ -401,6 +403,10 @@ async fn start_bench() -> Result<()> {
     assert!(benchmark_config.accounts.num_accounts >= benchmark_config.target_tps as usize);
     let workload = benchmark_config.resolved_workload();
 
+    // Install process-wide EIP-1559 fee caps from `[fee]` (defaults: tip 500 / maxFee 1000 Gwei).
+    let fees = benchmark_config.fee.to_gas_fees();
+    init_gas_fees(fees);
+
     // Initialize tracing
     let log_path = benchmark_config.log_path.trim();
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
@@ -446,6 +452,13 @@ async fn start_bench() -> Result<()> {
     };
 
     info!("Resolved workload: {:?}", workload);
+    info!(
+        "Fee caps: max_priority_fee={} Gwei, max_fee={} Gwei (7702 reserve ≈ {} wei @ gasLimit {})",
+        fees.tip_gwei(),
+        fees.max_fee_gwei(),
+        fees.reserve_wei(EIP7702_SET_CODE_GAS_LIMIT),
+        EIP7702_SET_CODE_GAS_LIMIT,
+    );
 
     // contract_config is only required for erc20 / swap workloads.
     // eip7702 only needs ETH funding + a delegate target contract.
@@ -621,9 +634,10 @@ async fn start_bench() -> Result<()> {
     let remained_eth = match workload {
         WorkloadType::Eip7702 => U256::ZERO,
         WorkloadType::Erc20 | WorkloadType::Swap => {
+            // Headroom for later token ops: num_tokens × 21k × maxFee.
             U256::from(benchmark_config.num_tokens)
-                * U256::from(21000)
-                * U256::from(1000_000_000_000u64)
+                * U256::from(21_000u64)
+                * U256::from(gas_fees().max_fee_per_gas)
         }
     };
     let eth_faucet_builder = PlanBuilder::create_faucet_tree_plan_builder(

--- a/src/txn_plan/constructor/approve.rs
+++ b/src/txn_plan/constructor/approve.rs
@@ -7,7 +7,7 @@ use alloy::{
 
 use crate::{
     config::IERC20,
-    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
+    eth::gas_fees,
     txn_plan::traits::FromTxnConstructor,
     util::gen_account::{AccountId, AccountManager},
 };
@@ -39,6 +39,7 @@ impl FromTxnConstructor for ApproveTokenConstructor {
         let call_data = approve_call.abi_encode();
         let call_data = Bytes::from(call_data);
         let from_address = account_generator.get_address_by_id(from_account_id);
+        let fees = gas_fees();
         // create transaction request
         let tx_request = TransactionRequest::default()
             .with_from(from_address)
@@ -46,8 +47,8 @@ impl FromTxnConstructor for ApproveTokenConstructor {
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(100_000); // Standard gas for approve
 
         Ok(tx_request)

--- a/src/txn_plan/constructor/eip7702.rs
+++ b/src/txn_plan/constructor/eip7702.rs
@@ -1,5 +1,5 @@
 use crate::{
-    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
+    eth::gas_fees,
     txn_plan::{addr_pool::AddressPool, FromTxnConstructor},
     util::gen_account::{AccountId, AccountManager},
 };
@@ -110,14 +110,15 @@ impl FromTxnConstructor for Eip7702Constructor {
         // Critical: `to` must be the EOA so delegated runtime runs in EOA
         // context and multiSend spends the EOA's ETH. Calling the template
         // address would execute with address(this) == template.
+        let fees = gas_fees();
         let tx_request = TransactionRequest::default()
             .with_from(from_address)
             .with_to(from_address)
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(EIP7702_SET_CODE_GAS_LIMIT)
             .with_authorization_list(vec![signed_auth]);
 

--- a/src/txn_plan/constructor/erc20_transfer.rs
+++ b/src/txn_plan/constructor/erc20_transfer.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::IERC20,
-    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
+    eth::gas_fees,
     txn_plan::{addr_pool::AddressPool, FromTxnConstructor},
     util::gen_account::{AccountId, AccountManager},
 };
@@ -50,6 +50,7 @@ impl FromTxnConstructor for Erc20TransferConstructor {
         let call_data = Bytes::from(call_data);
         let token_idx = rand::random::<usize>() % self.token_list.len();
         let token_address = self.token_list[token_idx];
+        let fees = gas_fees();
         // create transaction request
         let tx_request = TransactionRequest::default()
             .with_from(from_address)
@@ -57,8 +58,8 @@ impl FromTxnConstructor for Erc20TransferConstructor {
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(100_000); // Standard gas for ERC20 transfer
 
         Ok(tx_request)

--- a/src/txn_plan/constructor/faucet.rs
+++ b/src/txn_plan/constructor/faucet.rs
@@ -1,9 +1,12 @@
 use crate::{
+    eth::gas_fees,
     txn_plan::{
         faucet_plan::LevelFaucetPlan, faucet_txn_builder::FaucetTxnBuilder, traits::TxnPlan,
     },
     util::gen_account::{AccountGenerator, AccountId},
 };
+
+use super::eip7702::EIP7702_SET_CODE_GAS_LIMIT;
 use alloy::{
     primitives::{Address, U256},
     signers::local::PrivateKeySigner,
@@ -15,10 +18,12 @@ use std::{
 };
 use tracing::info;
 
-// Per-transaction gas cost budget (in wei). Keep in lockstep with
-// BENCH_MAX_FEE_PER_GAS × worst-case gas (EIP-7702 SetCode multiSend):
-// 1000 Gwei × 350_000 = 3.5e17 wei = 0.35 ETH/txn.
-const GAS_COST_PER_TXN_BUDGET: u64 = 350_000_000_000_000_000;
+/// Per-transaction gas cost budget (wei) for cascade leaf math.
+/// Locksteps to runtime `maxFee × EIP7702_SET_CODE_GAS_LIMIT` (worst-case
+/// mempool reserve among workloads).
+fn gas_cost_per_txn_budget() -> U256 {
+    U256::from(gas_fees().reserve_wei(EIP7702_SET_CODE_GAS_LIMIT))
+}
 
 static NONCE_MAP: std::sync::OnceLock<Arc<Mutex<HashMap<Address, Arc<AtomicU64>>>>> =
     std::sync::OnceLock::new();
@@ -60,7 +65,13 @@ impl<T: FaucetTxnBuilder + 'static> FaucetTreePlanBuilder<T> {
         let round_total_accounts_num = degree.pow(total_levels as u32);
 
         let degree_u256 = U256::from(degree);
-        let gas_cost_per_txn = U256::from(GAS_COST_PER_TXN_BUDGET);
+        let gas_cost_per_txn = gas_cost_per_txn_budget();
+        info!(
+            "Faucet gas_cost_per_txn_budget={} wei (maxFee_gwei={} × gasLimit={})",
+            gas_cost_per_txn,
+            gas_fees().max_fee_gwei(),
+            EIP7702_SET_CODE_GAS_LIMIT
+        );
 
         let (amount_per_recipient, intermediate_funding_amounts) = if total_levels > 1 {
             // This is a multi-level distribution.

--- a/src/txn_plan/constructor/mod.rs
+++ b/src/txn_plan/constructor/mod.rs
@@ -9,7 +9,7 @@ pub use approve::ApproveTokenConstructor;
 pub use distribute_token::SwapEthToTokenConstructor;
 pub use eip7702::{
     delegate_contract_bytecode, Eip7702Constructor, EIP7702_DEFAULT_BATCH_SIZE,
-    EIP7702_DELEGATE_DEPLOY_GAS_LIMIT,
+    EIP7702_DELEGATE_DEPLOY_GAS_LIMIT, EIP7702_SET_CODE_GAS_LIMIT,
 };
 pub use erc20_transfer::Erc20TransferConstructor;
 pub use faucet::FaucetTreePlanBuilder;

--- a/src/txn_plan/constructor/swap_token_2_token.rs
+++ b/src/txn_plan/constructor/swap_token_2_token.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{IUniswapV2Router, LiquidityPair},
-    eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS},
+    eth::gas_fees,
     txn_plan::{addr_pool::AddressPool, FromTxnConstructor},
     util::gen_account::{AccountId, AccountManager},
 };
@@ -61,14 +61,15 @@ impl FromTxnConstructor for SwapTokenToTokenConstructor {
         };
         let call_data = swap_call.abi_encode();
         let call_data = Bytes::from(call_data);
+        let fees = gas_fees();
         let tx_request = TransactionRequest::default()
             .with_from(from_address)
             .with_to(self.router_address)
             .with_input(call_data)
             .with_nonce(nonce)
             .with_chain_id(self.chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(100_000); // Standard gas for ETH transfer
         Ok(tx_request)
     }

--- a/src/txn_plan/faucet_txn_builder.rs
+++ b/src/txn_plan/faucet_txn_builder.rs
@@ -6,7 +6,7 @@ use alloy::{
     sol_types::SolCall,
 };
 
-use crate::eth::{BENCH_MAX_FEE_PER_GAS, BENCH_MAX_PRIORITY_FEE_PER_GAS};
+use crate::eth::gas_fees;
 
 // Define the ERC20 interface for transfer
 sol! {
@@ -42,13 +42,14 @@ impl FaucetTxnBuilder for EthFaucetTxnBuilder {
         nonce: u64,
         chain_id: u64,
     ) -> TransactionRequest {
+        let fees = gas_fees();
         TransactionRequest::default()
             .with_to(to)
             .with_value(value)
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(21_000) // Standard gas for ETH transfer
     }
 
@@ -78,6 +79,7 @@ impl FaucetTxnBuilder for Erc20FaucetTxnBuilder {
     ) -> TransactionRequest {
         // Create the ABI-encoded calldata for the ERC20 transfer function
         let calldata = IERC20::transferCall { to, amount: value };
+        let fees = gas_fees();
 
         TransactionRequest::default()
             .with_to(self.token_contract)
@@ -85,8 +87,8 @@ impl FaucetTxnBuilder for Erc20FaucetTxnBuilder {
             .with_input(calldata.abi_encode())
             .with_nonce(nonce)
             .with_chain_id(chain_id)
-            .with_max_priority_fee_per_gas(BENCH_MAX_PRIORITY_FEE_PER_GAS)
-            .with_max_fee_per_gas(BENCH_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(fees.max_priority_fee_per_gas)
+            .with_max_fee_per_gas(fees.max_fee_per_gas)
             .with_gas_limit(60_000) // A reasonable default for ERC20 transfers
     }
 


### PR DESCRIPTION
## Summary

Make EIP-1559 `maxPriorityFeePerGas` (tip) and `maxFeePerGas` configurable via toml `[fee]` instead of hardcoded constants. Defaults remain **tip 500 / maxFee 1000 Gwei** when `[fee]` is omitted, preserving previous behavior.

Hardcoded 500/1000 Gwei was ~10× real cost on public testnet (baseFee ~50 Gwei). Operators can now probe lower tips/maxFee without rebuilding.

### Config

```toml
# Put [fee] AFTER top-level keys (e.g. nodes=); never before bare keys —
# TOML table scoping would nest subsequent bare keys under [fee].
[fee]
max_fee_per_gas_gwei = 100
max_priority_fee_per_gas_gwei = 10
```

| Field | Default | Notes |
|-------|---------|-------|
| `max_fee_per_gas_gwei` | 1000 | Keep ≥ tip; for Gravity min baseFee ~50 use `max_fee ≥ tip + 50` so tip fully applies |
| `max_priority_fee_per_gas_gwei` | 500 | Empirically high for promote under load; idle testnet often works much lower |

### Behavior

- `FeeConfig` → `GasFees` (wei), installed once via `init_gas_fees` after config load
- All constructors + faucet builders use `gas_fees()` instead of `BENCH_*` constants
- **Faucet cascade budget locksteps**: `maxFee × EIP7702_SET_CODE_GAS_LIMIT` (was hardcoded 0.35 ETH)
- Invalid config (`maxFee < tip`, zero values) rejected at load time
- `scripts/deploy.py`: clamp `gasPrice` under public RPC 1 ETH txfeecap; report post-LP on-chain token balance as `faucet_balance`

### Base branch

Targets `feat/eip7702-workload` because faucet budget uses `EIP7702_SET_CODE_GAS_LIMIT` from that branch.

## Test plan

- [x] `cargo fmt` + `cargo check`
- [x] Defaults omit path: same 500/1000 as before
- [x] gravity-dev testnet erc20 smoke with tip=10 / maxFee=100 (lower cost, txs still land)
- [ ] CI green on this PR
- [ ] Optional: eip7702 workload with lowered fees still under txfeecap (`gasLimit × maxFee < 1 ETH`)